### PR TITLE
Recall and use region instance was launched in

### DIFF
--- a/lib/vagrant-aws/action/connect_aws.rb
+++ b/lib/vagrant-aws/action/connect_aws.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
 
         def call(env)
           # Get the region we're going to booting up in
-          region = env[:machine].provider_config.region
+          region = env[:machine].provider.region
 
           # Get the configs
           region_config = env[:machine].provider_config.get_region_config(region)

--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -132,6 +132,11 @@ module VagrantPlugins
           # Immediately save the ID since it is created at this point.
           env[:machine].id = server.id
 
+          # Immediately save the region in which the instance was launched.
+          env[:machine].data_dir.join("region").open("w+") do |f|
+            f.write(region)
+          end
+
           # Wait for the instance to be ready first
           env[:metrics]["instance_ready_time"] = Util::Timer.time do
             tries = region_config.instance_ready_timeout / 2

--- a/lib/vagrant-aws/provider.rb
+++ b/lib/vagrant-aws/provider.rb
@@ -41,6 +41,18 @@ module VagrantPlugins
         Vagrant::MachineState.new(state_id, short, long)
       end
 
+      def region
+        # Return the region associated with the instance if the machine
+        # has already been launched, or return the default region configured.
+        machine_region_file = @machine.data_dir.join("region")
+
+        if File.exists?(machine_region_file)
+          return File.read(machine_region_file)
+        else
+          return @machine.provider_config.region
+        end
+      end
+
       def to_s
         id = @machine.id.nil? ? "new" : @machine.id
         "AWS (#{id})"


### PR DESCRIPTION
When region configuration changes, the AWS provider loses track of the
launched instance because it attempts to find it by ID in the wrong
region. This commit addresses this issue by immediately saving the
region the instance was launched in into the machine's data directory
after the instance is launched. When the provider connects to AWS, it
will check if the machine's region state is already known, and will use
it if so, otherwise the connection will fallback to the default region
that is presently configured.