### PR TITLE
Implement a post-terminate callback parameter, and use provider.region instead of provider_config.region

### DIFF
--- a/lib/vagrant-aws/action/package_instance.rb
+++ b/lib/vagrant-aws/action/package_instance.rb
@@ -52,7 +52,7 @@ module VagrantPlugins
             env[:metrics]["instance_ready_time"] = Util::Timer.time do
               
               # Get the config, to set the ami burn timeout
-              region = env[:machine].provider_config.region
+              region = env[:machine].provider.region
               region_config = env[:machine].provider_config.get_region_config(region)
               tries = region_config.instance_package_timeout / 2
 
@@ -128,7 +128,7 @@ module VagrantPlugins
         def create_vagrantfile env
           File.open(File.join(env["export.temp_dir"], "Vagrantfile"), "w") do |f|
             f.write(TemplateRenderer.render("vagrant-aws_package_Vagrantfile", {
-              region: env[:machine].provider_config.region,
+              region: env[:machine].provider.region,
               ami: @ami_id,
               template_root: template_root
             }))

--- a/lib/vagrant-aws/action/read_ssh_info.rb
+++ b/lib/vagrant-aws/action/read_ssh_info.rb
@@ -31,7 +31,7 @@ module VagrantPlugins
 
           # read attribute override
           ssh_host_attribute = machine.provider_config.
-              get_region_config(machine.provider_config.region).ssh_host_attribute
+              get_region_config(machine.provider.region).ssh_host_attribute
           # default host attributes to try. NOTE: Order matters!
           ssh_attrs = [:dns_name, :public_ip_address, :private_ip_address]
           ssh_attrs = (Array(ssh_host_attribute) + ssh_attrs).uniq if ssh_host_attribute

--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
           env[:metrics] ||= {}
 
           # Get the region we're going to booting up in
-          region = env[:machine].provider_config.region
+          region = env[:machine].provider.region
 
           # Get the configs
           region_config         = env[:machine].provider_config.get_region_config(region)

--- a/lib/vagrant-aws/action/terminate_instance.rb
+++ b/lib/vagrant-aws/action/terminate_instance.rb
@@ -13,7 +13,7 @@ module VagrantPlugins
 
         def call(env)
           server         = env[:aws_compute].servers.get(env[:machine].id)
-          region         = env[:machine].provider_config.region
+          region         = env[:machine].provider.region
           region_config  = env[:machine].provider_config.get_region_config(region)
 
           elastic_ip     = region_config.elastic_ip
@@ -29,6 +29,11 @@ module VagrantPlugins
           env[:ui].info(I18n.t("vagrant_aws.terminating"))
           server.destroy
           env[:machine].id = nil
+
+          # Run a "post-terminate" callback for cleanup if provided
+          if env[:machine].provider_config.post_terminate_callback
+            env[:machine].provider_config.post_terminate_callback.call(env)
+          end
 
           @app.call(env)
         end

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -211,6 +211,11 @@ module VagrantPlugins
       # @return [Time]
       attr_accessor :spot_valid_until
 
+      # Post terminate callback
+      #
+      # @return [Proc]
+      attr_accessor :post_terminate_callback
+
       # The product description for the spot price history
       #
       # @return [String]
@@ -256,6 +261,7 @@ module VagrantPlugins
         @spot_instance             = UNSET_VALUE
         @spot_max_price            = UNSET_VALUE
         @spot_valid_until          = UNSET_VALUE
+        @post_terminate_callback   = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -440,6 +446,9 @@ module VagrantPlugins
 
         # Default: Request is effective indefinitely.
         @spot_valid_until = nil if @spot_valid_until == UNSET_VALUE
+
+        # default to nil
+        @post_terminate_callback = nil if @post_terminate_callback == UNSET_VALUE
 
         # default to nil
         @spot_price_product_description = nil if @spot_price_product_description == UNSET_VALUE

--- a/lib/vagrant-aws/util/elb.rb
+++ b/lib/vagrant-aws/util/elb.rb
@@ -34,7 +34,7 @@ module VagrantPlugins
         instances = env[:aws_compute].servers.all("instance-id" => elb.instances)
         
         azs = if instances.empty?
-                ["#{env[:machine].provider_config.region}a"]
+                ["#{env[:machine].provider.region}a"]
               else
                 instances.map(&:availability_zone).uniq
               end


### PR DESCRIPTION
- **Get region value from provider.region:**
Commit a12ccea4 added code to persist the region associated with an instance to use it later on when searching for the instance on AWS. The modification added a function in the provider that returns the region either from this saved state or from the default configuration. This fix updates the code at various points to use this function rather then rely on the default configuration for the region value.

- **Allow user to run post-termination tasks via callback:**
Adds a feature which allows the user to provide a Proc callback to the VagrantPlugins::AWS::Config class. If set, then immediately after the instance is terminated (in the destroy lifecycle), the callback will get called. This facilitates use-cases where the user needs to do post-destroy cleanup tasks, such as removing associated Route53 records or anything else. Example usage below:

```
      config.vm.provider 'aws' do |aws, config|
        aws.post_terminate_callback = lambda do |env|
          region = env[:machine].provider.region
          region_config = env[:machine].provider_config.get_region_config(region)
          fog_dns = Fog::DNS.new({
            :provider => :aws,
            :aws_access_key_id => region_config.access_key_id,
            :aws_secret_access_key => region_config.secret_access_key
          })

          zone = fog_dns.zones.find { |z| z.domain == dns_zone }
          raise "Route53 DNS zone #{dns_zone} not found" unless zone

          record = zone.records.find { |r| r.name == dns_name }
          if record == nil
            env[:ui].info("Route53 DNS record #{dns_name} not found")
          else
            env[:ui].info("Removing Route53 DNS record #{dns_name}")
            record.destroy
          end
        end
      end
```