### PR TITLE
Get region value from provider.region, fix for a12ccea4

### DIFF
--- a/lib/vagrant-aws/action/package_instance.rb
+++ b/lib/vagrant-aws/action/package_instance.rb
@@ -52,7 +52,7 @@ module VagrantPlugins
             env[:metrics]["instance_ready_time"] = Util::Timer.time do
               
               # Get the config, to set the ami burn timeout
-              region = env[:machine].provider_config.region
+              region = env[:machine].provider.region
               region_config = env[:machine].provider_config.get_region_config(region)
               tries = region_config.instance_package_timeout / 2
 
@@ -128,7 +128,7 @@ module VagrantPlugins
         def create_vagrantfile env
           File.open(File.join(env["export.temp_dir"], "Vagrantfile"), "w") do |f|
             f.write(TemplateRenderer.render("vagrant-aws_package_Vagrantfile", {
-              region: env[:machine].provider_config.region,
+              region: env[:machine].provider.region,
               ami: @ami_id,
               template_root: template_root
             }))

--- a/lib/vagrant-aws/action/read_ssh_info.rb
+++ b/lib/vagrant-aws/action/read_ssh_info.rb
@@ -31,7 +31,7 @@ module VagrantPlugins
 
           # read attribute override
           ssh_host_attribute = machine.provider_config.
-              get_region_config(machine.provider_config.region).ssh_host_attribute
+              get_region_config(machine.provider.region).ssh_host_attribute
           # default host attributes to try. NOTE: Order matters!
           ssh_attrs = [:dns_name, :public_ip_address, :private_ip_address]
           ssh_attrs = (Array(ssh_host_attribute) + ssh_attrs).uniq if ssh_host_attribute

--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
           env[:metrics] ||= {}
 
           # Get the region we're going to booting up in
-          region = env[:machine].provider_config.region
+          region = env[:machine].provider.region
 
           # Get the configs
           region_config         = env[:machine].provider_config.get_region_config(region)

--- a/lib/vagrant-aws/action/terminate_instance.rb
+++ b/lib/vagrant-aws/action/terminate_instance.rb
@@ -13,7 +13,7 @@ module VagrantPlugins
 
         def call(env)
           server         = env[:aws_compute].servers.get(env[:machine].id)
-          region         = env[:machine].provider_config.region
+          region         = env[:machine].provider.region
           region_config  = env[:machine].provider_config.get_region_config(region)
 
           elastic_ip     = region_config.elastic_ip

--- a/lib/vagrant-aws/util/elb.rb
+++ b/lib/vagrant-aws/util/elb.rb
@@ -34,7 +34,7 @@ module VagrantPlugins
         instances = env[:aws_compute].servers.all("instance-id" => elb.instances)
         
         azs = if instances.empty?
-                ["#{env[:machine].provider_config.region}a"]
+                ["#{env[:machine].provider.region}a"]
               else
                 instances.map(&:availability_zone).uniq
               end


### PR DESCRIPTION
Commit a12ccea4 added code to persist the region associated with an
instance to use it later on when searching for the instance on AWS.
The modification added a function in the provider that returns the
region either from this saved state or from the default configuration.
This fix updates the code at various points to use this function rather
then rely on the default configuration for the region value.