### PR TITLE
Allow user to run post-termination tasks via callback

### DIFF
--- a/lib/vagrant-aws/action/terminate_instance.rb
+++ b/lib/vagrant-aws/action/terminate_instance.rb
@@ -30,6 +30,11 @@ module VagrantPlugins
           server.destroy
           env[:machine].id = nil
 
+          # Run a "post-terminate" callback for cleanup if provided
+          if env[:machine].provider_config.post_terminate_callback
+            env[:machine].provider_config.post_terminate_callback.call(env)
+          end
+
           @app.call(env)
         end
 

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -211,6 +211,11 @@ module VagrantPlugins
       # @return [Time]
       attr_accessor :spot_valid_until
 
+      # Post terminate callback
+      #
+      # @return [Proc]
+      attr_accessor :post_terminate_callback
+
       # The product description for the spot price history
       #
       # @return [String]
@@ -256,6 +261,7 @@ module VagrantPlugins
         @spot_instance             = UNSET_VALUE
         @spot_max_price            = UNSET_VALUE
         @spot_valid_until          = UNSET_VALUE
+        @post_terminate_callback   = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -440,6 +446,9 @@ module VagrantPlugins
 
         # Default: Request is effective indefinitely.
         @spot_valid_until = nil if @spot_valid_until == UNSET_VALUE
+
+        # default to nil
+        @post_terminate_callback = nil if @post_terminate_callback == UNSET_VALUE
 
         # default to nil
         @spot_price_product_description = nil if @spot_price_product_description == UNSET_VALUE


### PR DESCRIPTION
This commit adds a feature which allows the user to provide a Proc
callback to the VagrantPlugins::AWS::Config class. If set, then
immediately after the instance is terminated (in the destroy lifecycle),
the callback will get called. This facilitates use-cases where the user
needs to do post-terminate cleanup work, such as removing associated
Route53 records or anything else.